### PR TITLE
Query by event dates

### DIFF
--- a/includes/connection/class-events.php
+++ b/includes/connection/class-events.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Connection - Events
+ *
+ * Registers connections to Events
+ *
+ * @package WPGraphQL\Extensions\QL_Events\Connection
+ * @since   0.0.1
+ */
+
+namespace WPGraphQL\Extensions\QL_Events\Connection;
+
+use WPGraphQL\TypeRegistry;
+
+/**
+ * Class - Events
+ */
+class Events {
+	/**
+	 * Filters
+	 */
+	public static function where_args() {
+		return array(
+			'startDateQuery' => array(
+				'type'        => TypeRegistry::get_type( 'DateQueryInput' ),
+				'description' => __( 'Filter the connection based on event start dates', 'ql-events' ),
+			),
+			'endDateQuery'   => array(
+				'type'        => TypeRegistry::get_type( 'DateQueryInput' ),
+				'description' => __( 'Filter the connection based on event end dates', 'ql-events' ),
+			),
+		);
+	}
+}

--- a/includes/connection/class-tickets.php
+++ b/includes/connection/class-tickets.php
@@ -25,7 +25,7 @@ class Tickets extends PostObjects {
 	public static function register_connections() {
 		$rsvp = RSVP::get_instance();
 
-		if ( TEC_EVENT_TICKETS_LOADED ) {
+		if ( \QL_Events::is_ticket_events_loaded() ) {
 			// From Event to RSVPTickets.
 			$rsvp = tribe( 'tickets.rsvp' );
 			register_graphql_connection(
@@ -52,7 +52,7 @@ class Tickets extends PostObjects {
 			);
 		}
 
-		if ( TEC_EVENT_TICKETS_PLUS_LOADED ) {
+		if ( \QL_Events::is_ticket_events_plus_loaded() ) {
 			// From Event to WooTicket.
 			$woocommerce = tribe( 'tickets-plus.commerce.woo' );
 			register_graphql_connection(

--- a/includes/data/connection/class-attendee-connection-resolver.php
+++ b/includes/data/connection/class-attendee-connection-resolver.php
@@ -56,7 +56,7 @@ class Attendee_Connection_Resolver {
 		}
 
 		$query_args = apply_filters(
-			'graphql_' . Main::ORGANIZER_POST_TYPE . '_connection_query_args',
+			'graphql_rsvp_attendee_connection_query_args',
 			$query_args,
 			$source,
 			$args,

--- a/includes/data/connection/class-event-connection-resolver.php
+++ b/includes/data/connection/class-event-connection-resolver.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Connection resolver - Events
+ *
+ * Filters connections to Organizer types
+ *
+ * @package WPGraphQL\Extensions\QL_Events\Data\Connection
+ * @since 0.0.1
+ */
+
+namespace WPGraphQL\Extensions\QL_Events\Data\Connection;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use Tribe__Events__Main as Main;
+use WPGraphQL\AppContext;
+use WPGraphQL\Model\Post;
+
+/**
+ * Class Event_Connection_Resolver
+ */
+class Event_Connection_Resolver {
+	/**
+	 * This prepares the $query_args for use in the connection query. This is where default $args are set, where dynamic
+	 * $args from the $this->source get set, and where mapping the input $args to the actual $query_args occurs.
+	 *
+	 * @param array       $query_args - WP_Query args.
+	 * @param mixed       $source     - Connection parent resolver.
+	 * @param array       $args       - Connection arguments.
+	 * @param AppContext  $context    - AppContext object.
+	 * @param ResolveInfo $info       - ResolveInfo object.
+	 *
+	 * @return mixed
+	 */
+	public static function get_query_args( $query_args, $source, $args, $context, $info ) {
+		/**
+		 * Collect the input_fields and sanitize them to prepare them for sending to the WP_Query
+		 */
+		$input_fields = [];
+		if ( ! empty( $args['where'] ) ) {
+			$input_fields = self::sanitize_input_fields( $args['where'] );
+		}
+
+		/**
+		 * Merge the input_fields with the default query_args
+		 */
+		if ( ! empty( $input_fields ) ) {
+			$query_args = array_merge( $query_args, $input_fields );
+		}
+
+		return apply_filters(
+			'graphql_' . Main::POSTTYPE . '_connection_query_args',
+			$query_args,
+			$source,
+			$args,
+			$context,
+			$info
+		);
+	}
+
+	/**
+	 * This sets up the "allowed" args, and translates the GraphQL-friendly keys to WP_Query
+	 * friendly keys. There's probably a cleaner/more dynamic way to approach this, but
+	 * this was quick. I'd be down to explore more dynamic ways to map this, but for
+	 * now this gets the job done.
+	 *
+	 * @since  0.0.5
+	 * @access private
+	 *
+	 * @param array $args  Where argument input.
+	 *
+	 * @return array
+	 */
+	private static function sanitize_input_fields( $args ) {
+		$query_args = array();
+
+		if ( ! empty( $args['startDateQuery'] ) ) {
+			$query_args['meta_query']   = array(); // WPCS: slow query ok.
+			$query_args['meta_query'][] = self::date_query_input_to_meta_query( $args['startDateQuery'], '_EventStartDate' );
+		}
+
+		if ( ! empty( $args['endDateQuery'] ) ) {
+			if ( ! isset( $query_args['meta_query'] ) ) {
+				$query_args['meta_query'] = array(); // WPCS: slow query ok.
+			}
+			$query_args['meta_query'][] = self::date_query_input_to_meta_query( $args['endDateQuery'], '_EventEndDate' );
+		}
+
+		return $query_args;
+	}
+
+	/**
+	 * Takes a DateQueryInput and returns a meta query array.
+	 *
+	 * @param array  $date_query_input  DateQueryInput.
+	 * @param string $meta_key          Target date meta key.
+	 *
+	 * @return array
+	 */
+	private static function date_query_input_to_meta_query( $date_query_input, $meta_key ) {
+		// Create date string.
+		$year   = isset( $date_query_input['year'] );
+		$month  = isset( $date_query_input['month'] );
+		$day    = isset( $date_query_input['day'] );
+		$hour   = isset( $date_query_input['hour'] );
+		$minute = isset( $date_query_input['minute'] );
+		$second = isset( $date_query_input['second'] );
+		$week   = isset( $date_query_input['week'] );
+		$after  = isset( $date_query_input['after'] );
+		$before = isset( $date_query_input['before'] );
+
+		switch ( true ) {
+			case $year && $month && $day && $hour:
+				$date  = sprintf(
+					'%4d-%02d-%02d %02d',
+					$date_query_input['year'],
+					$date_query_input['month'],
+					$date_query_input['day'],
+					$date_query_input['hour']
+				);
+				$date .= $minute ? sprintf( ':%02d', $date_query_input['minute'] ) : ':00';
+				$date .= $second ? sprintf( ':%02d', $date_query_input['second'] ) : ':00';
+				$type  = 'DATETIME';
+				break;
+			case $year && $month && $day:
+				$date = sprintf(
+					'%4d-%02d-%02d',
+					$date_query_input['year'],
+					$date_query_input['month'],
+					$date_query_input['day']
+				);
+				break;
+			case $year && $month:
+				$date = sprintf( '%4d-%02d', $date_query_input['year'], $date_query_input['month'] );
+				break;
+			case $year && $week:
+				$date = sprintf( '%4dW%02d', $date_query_input['year'], $date_query_input['week'] );
+				break;
+			case $year:
+				$date = sprintf( '%4d', $date_query_input['year'] );
+				break;
+			case $after:
+				$date = isset( $date_query_input['after']['year'] )
+					? sprintf( '%4d', $date_query_input['after']['year'] )
+					: date( 'Y' );
+
+				$date .= isset( $date_query_input['after']['month'] )
+					? sprintf( '-%02d', $date_query_input['after']['month'] )
+					: '-' . date( 'm' );
+
+				$date .= isset( $date_query_input['after']['day'] )
+					? sprintf( '-%02d', $date_query_input['after']['day'] )
+					: '-' . date( 'd' );
+
+				$compare = '>';
+				break;
+			case $before:
+				$date = isset( $date_query_input['before']['year'] )
+					? sprintf( '%4d', $date_query_input['before']['year'] )
+					: date( 'Y' );
+
+				$date .= isset( $date_query_input['before']['month'] )
+					? sprintf( '-%02d', $date_query_input['before']['month'] )
+					: '-' . date( 'm' );
+
+				$date .= isset( $date_query_input['before']['day'] )
+					? sprintf( '-%02d', $date_query_input['before']['day'] )
+					: '-' . date( 'd' );
+
+				$compare = '<';
+				break;
+			default:
+				$date = date( 'Y-m-d' );
+		}
+
+		// Get compare value.
+		if ( isset( $date_query_input['compare'] ) ) {
+			if ( 'after' === strtolower( $date_query_input['compare'] ) ) {
+				$compare = '>';
+			} elseif ( 'before' === strtolower( $date_query_input['compare'] ) ) {
+				$compare = '<';
+			} else {
+				$compare = $date_query_input['compare'];
+			}
+		}
+
+		return array(
+			'key'     => $meta_key,
+			'value'   => $date,
+			'compare' => isset( $compare ) ? $compare : '=',
+			'type'    => isset( $type ) ? $type : 'DATE',
+		);
+	}
+}

--- a/includes/data/connection/class-organizer-connection-resolver.php
+++ b/includes/data/connection/class-organizer-connection-resolver.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Connection resolver - Organizer
+ * Connection resolver - Organizers
  *
  * Filters connections to Organizer types
  *

--- a/ql-events.php
+++ b/ql-events.php
@@ -59,10 +59,10 @@ function ql_events_constants() {
  */
 function ql_events_dependencies_not_ready() {
 	$deps = [];
-	if ( ! class_exists( '\WPGraphQL' ) ) {
+	if ( ! class_exists( 'WPGraphQL' ) ) {
 		$deps[] = 'WPGraphQL';
 	}
-	if ( ! class_exists( '\Tribe__Events__Main' ) ) {
+	if ( ! class_exists( 'Tribe__Events__Main' ) ) {
 		$deps[] = 'The Events Calendar';
 	}
 

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -279,7 +279,7 @@ class ClassLoader
      */
     public function setApcuPrefix($apcuPrefix)
     {
-        $this->apcuPrefix = function_exists('apcu_fetch') && ini_get('apc.enabled') ? $apcuPrefix : null;
+        $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
 
     /**

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -8,10 +8,12 @@ $baseDir = dirname($vendorDir);
 return array(
     'QL_Events' => $baseDir . '/includes/class-ql-events.php',
     'WPGraphQL\\Extensions\\QL_Events\\Connection\\Attendees' => $baseDir . '/includes/connection/class-attendees.php',
+    'WPGraphQL\\Extensions\\QL_Events\\Connection\\Events' => $baseDir . '/includes/connection/class-events.php',
     'WPGraphQL\\Extensions\\QL_Events\\Connection\\Organizers' => $baseDir . '/includes/connection/class-organizers.php',
     'WPGraphQL\\Extensions\\QL_Events\\Connection\\Tickets' => $baseDir . '/includes/connection/class-tickets.php',
     'WPGraphQL\\Extensions\\QL_Events\\Core_Schema_Filters' => $baseDir . '/includes/class-core-schema-filters.php',
     'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Attendee_Connection_Resolver' => $baseDir . '/includes/data/connection/class-attendee-connection-resolver.php',
+    'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Event_Connection_Resolver' => $baseDir . '/includes/data/connection/class-event-connection-resolver.php',
     'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Organizer_Connection_Resolver' => $baseDir . '/includes/data/connection/class-organizer-connection-resolver.php',
     'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Ticket_Connection_Resolver' => $baseDir . '/includes/data/connection/class-ticket-connection-resolver.php',
     'WPGraphQL\\Extensions\\QL_Events\\Data\\Factory' => $baseDir . '/includes/data/class-factory.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -23,10 +23,12 @@ class ComposerStaticInitbe877364d45ac961bba01ffe749c79f4
     public static $classMap = array (
         'QL_Events' => __DIR__ . '/../..' . '/includes/class-ql-events.php',
         'WPGraphQL\\Extensions\\QL_Events\\Connection\\Attendees' => __DIR__ . '/../..' . '/includes/connection/class-attendees.php',
+        'WPGraphQL\\Extensions\\QL_Events\\Connection\\Events' => __DIR__ . '/../..' . '/includes/connection/class-events.php',
         'WPGraphQL\\Extensions\\QL_Events\\Connection\\Organizers' => __DIR__ . '/../..' . '/includes/connection/class-organizers.php',
         'WPGraphQL\\Extensions\\QL_Events\\Connection\\Tickets' => __DIR__ . '/../..' . '/includes/connection/class-tickets.php',
         'WPGraphQL\\Extensions\\QL_Events\\Core_Schema_Filters' => __DIR__ . '/../..' . '/includes/class-core-schema-filters.php',
         'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Attendee_Connection_Resolver' => __DIR__ . '/../..' . '/includes/data/connection/class-attendee-connection-resolver.php',
+        'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Event_Connection_Resolver' => __DIR__ . '/../..' . '/includes/data/connection/class-event-connection-resolver.php',
         'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Organizer_Connection_Resolver' => __DIR__ . '/../..' . '/includes/data/connection/class-organizer-connection-resolver.php',
         'WPGraphQL\\Extensions\\QL_Events\\Data\\Connection\\Ticket_Connection_Resolver' => __DIR__ . '/../..' . '/includes/data/connection/class-ticket-connection-resolver.php',
         'WPGraphQL\\Extensions\\QL_Events\\Data\\Factory' => __DIR__ . '/../..' . '/includes/data/class-factory.php',


### PR DESCRIPTION
Adds `startDateQuery` and `endDateQuery` arguments to the `Event` connections. Its function my be a little different from `dateQuery` which using the same input type but isn't based upon a meta value.

#### Example usage
```
query {
  events( where: {startDateQuery: {
    year: 2019
    month: 8
    day: 12
    hour: 23
    minute: 2
    second: 40
    compare: "after"
  }}) {
    ...event connection fields
  }
}
```

```
query {
  events( where: {startDateQuery: {
    after: {
      month: 8
      day: 23
    }
  }}) {
    ...event connection fields
  }
}
```