### PR TITLE
WooTicket catalog visibility fixed

### DIFF
--- a/includes/class-core-schema-filters.php
+++ b/includes/class-core-schema-filters.php
@@ -75,6 +75,13 @@ class Core_Schema_Filters {
 				10,
 				5
 			);
+
+			add_filter(
+				'graphql_product_connection_catalog_visibility',
+				array( __CLASS__, 'wooticket_default_visibility' ),
+				10,
+				6
+			);
 		}
 	}
 
@@ -242,5 +249,22 @@ class Core_Schema_Filters {
 	 */
 	public static function ticket_plus_connection_query_args( $query_args, $source, $args, $context, $info ) {
 		return \WPGraphQL\Extensions\QL_Events\Data\Connection\Ticket_Connection_Resolver::get_ticket_plus_args( $query_args, $source, $args, $context, $info );
+	}
+
+	/**
+	 * Filter PostObjectConnectionResolver's query_args and adds args to used when querying
+	 * Ticket Events Plus' "Ticket" CPTs
+	 *
+	 * @param array       $default_visibility  Default catalog visibility tax query.
+	 * @param array       $query_args - WP_Query args.
+	 * @param mixed       $source     - Connection parent resolver.
+	 * @param array       $args       - Connection arguments.
+	 * @param AppContext  $context    - AppContext object.
+	 * @param ResolveInfo $info       - ResolveInfo object.
+	 *
+	 * @return mixed
+	 */
+	public static function wooticket_default_visibility( $default_visibility, $query_args, $source, $args, $context, $info ) {
+		return \WPGraphQL\Extensions\QL_Events\Data\Connection\Ticket_Connection_Resolver::get_ticket_plus_default_visibility( $default_visibility, $query_args, $source, $args, $context, $info );
 	}
 }

--- a/includes/data/connection/class-ticket-connection-resolver.php
+++ b/includes/data/connection/class-ticket-connection-resolver.php
@@ -109,4 +109,32 @@ class Ticket_Connection_Resolver {
 
 		return $query_args;
 	}
+
+	/**
+	 * Prepares default product connection catalog visibility for this "wooTicket" connection.
+	 *
+	 * @param array       $default_visibility  Default catalog visibility tax query.
+	 * @param array       $query_args          The args that will be passed to the WP_Query.
+	 * @param mixed       $source              The source that's passed down the GraphQL queries.
+	 * @param array       $args                The inputArgs on the field.
+	 * @param AppContext  $context             The AppContext passed down the GraphQL tree.
+	 * @param ResolveInfo $info                The ResolveInfo passed down the GraphQL tree.
+	 *
+	 * @return mixed
+	 */
+	public static function get_ticket_plus_default_visibility( $default_visibility, $query_args, $source, $args, $context, $info ) {
+		if ( $source instanceof Post ) {
+			// @codingStandardsIgnoreLine
+			if ( 'wooTickets' === $info->fieldName ) {
+				$default_visibility = array(
+					'taxonomy' => 'product_visibility',
+					'field'    => 'slug',
+					'terms'    => array( 'exclude-from-catalog', 'exclude-from-search' ),
+					'operator' => 'IN',
+				);
+			}
+		}
+
+		return $default_visibility;
+	}
 }


### PR DESCRIPTION
Fixes `wooTickets` product visibility for non-adminstrator requests, rely on changes make in WooGraphQL PR [#142](https://github.com/wp-graphql/wp-graphql-woocommerce/pull/142)