### PR TITLE
Query Events by Venue

### DIFF
--- a/includes/connection/class-events.php
+++ b/includes/connection/class-events.php
@@ -10,6 +10,7 @@
 
 namespace WPGraphQL\Extensions\QL_Events\Connection;
 
+use WPGraphQL\Types;
 use WPGraphQL\TypeRegistry;
 
 /**
@@ -21,6 +22,14 @@ class Events {
 	 */
 	public static function where_args() {
 		return array(
+			'venuesIn'         => array(
+				'type'        => Types::list_of( TypeRegistry::get_type( 'Int' ) ),
+				'description' => __( 'Filter the connection based on event venue ID', 'ql-events' ),
+			),
+			'venuesNotIn'         => array(
+				'type'        => Types::list_of( TypeRegistry::get_type( 'Int' ) ),
+				'description' => __( 'Filter the connection based on event venue ID', 'ql-events' ),
+			),
 			'startDateQuery' => array(
 				'type'        => TypeRegistry::get_type( 'DateQueryInput' ),
 				'description' => __( 'Filter the connection based on event start dates', 'ql-events' ),

--- a/includes/data/connection/class-event-connection-resolver.php
+++ b/includes/data/connection/class-event-connection-resolver.php
@@ -85,6 +85,28 @@ class Event_Connection_Resolver {
 			$query_args['meta_query'][] = self::date_query_input_to_meta_query( $args['endDateQuery'], '_EventEndDate' );
 		}
 
+		if ( ! empty( $args['venuesIn'] ) ) {
+			if ( ! isset( $query_args['meta_query'] ) ) {
+				$query_args['meta_query'] = array(); // WPCS: slow query ok.
+			}
+			$query_args['meta_query'][] = array(
+				'key'     => '_EventVenueID',
+				'value'   => $args['venuesIn'],
+				'compare' => 'IN',
+			);
+		}
+
+		if ( ! empty( $args['venuesNotIn'] ) ) {
+			if ( ! isset( $query_args['meta_query'] ) ) {
+				$query_args['meta_query'] = array(); // WPCS: slow query ok.
+			}
+			$query_args['meta_query'][] = array(
+				'key'     => '_EventVenueID',
+				'value'   => $args['venuesNotIn'],
+				'compare' => 'NOT IN',
+			);
+		}
+
 		return $query_args;
 	}
 


### PR DESCRIPTION
Adds "venuesIn" and "venuesNotIn" arguments to the Events connections for filtering by Venue ID.

#### Example Usage
```
{
  events(where:{ venuesIn: [1004,1422] }) {
    nodes {
    	id 
    }
  }
}
```
#### Issues closed
#9 