### PR TITLE
Set Ticket $connection_type to false by default

### DIFF
--- a/includes/data/connection/class-ticket-connection-resolver.php
+++ b/includes/data/connection/class-ticket-connection-resolver.php
@@ -45,6 +45,7 @@ class Ticket_Connection_Resolver {
 					$connection_type = 'paypal_tickets';
 					break;
 				default:
+					$connection_type = false;
 					break;
 			}
 		}


### PR DESCRIPTION
Resolves the following PHP error: `PHP Notice:  Undefined variable: connection_type in /ql-events/includes/data/connection/class-ticket-connection-resolver.php on line 52`. 

This error seems to arise when WooTickets are used instead of RSVP or Paypal Commerce.

Stack trace:

```
[27-Dec-2020 12:27:44 UTC] PHP Stack trace:
[27-Dec-2020 12:27:44 UTC] PHP   1. {main}() /var/www/thegsc/index.php:0
[27-Dec-2020 12:27:44 UTC] PHP   2. require() /var/www/thegsc/index.php:17
[27-Dec-2020 12:27:44 UTC] PHP   3. wp() /var/www/thegsc/wp-blog-header.php:16
[27-Dec-2020 12:27:44 UTC] PHP   4. WP->main() /var/www/thegsc/wp-includes/functions.php:1291
[27-Dec-2020 12:27:44 UTC] PHP   5. WP->parse_request() /var/www/thegsc/wp-includes/class-wp.php:745
[27-Dec-2020 12:27:44 UTC] PHP   6. do_action_ref_array() /var/www/thegsc/wp-includes/class-wp.php:388
[27-Dec-2020 12:27:44 UTC] PHP   7. WP_Hook->do_action() /var/www/thegsc/wp-includes/plugin.php:551
[27-Dec-2020 12:27:44 UTC] PHP   8. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/class-wp-hook.php:311
[27-Dec-2020 12:27:44 UTC] PHP   9. WPGraphQL\Router::resolve_http_request() /var/www/thegsc/wp-includes/class-wp-hook.php:287
[27-Dec-2020 12:27:44 UTC] PHP  10. WPGraphQL\Router::process_http_request() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Router.php:252
[27-Dec-2020 12:27:44 UTC] PHP  11. WPGraphQL\Request->execute_http() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Router.php:426
[27-Dec-2020 12:27:44 UTC] PHP  12. GraphQL\Server\StandardServer->executeRequest() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Request.php:599
[27-Dec-2020 12:27:44 UTC] PHP  13. GraphQL\Server\Helper->executeOperation() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Server/StandardServer.php:135
[27-Dec-2020 12:27:44 UTC] PHP  14. GraphQL\Server\Helper->promiseToExecuteOperation() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Server/Helper.php:211
[27-Dec-2020 12:27:44 UTC] PHP  15. GraphQL\GraphQL::promiseToExecute() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Server/Helper.php:311
[27-Dec-2020 12:27:44 UTC] PHP  16. GraphQL\Executor\Executor::promiseToExecute() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/GraphQL.php:162
[27-Dec-2020 12:27:44 UTC] PHP  17. GraphQL\Executor\ReferenceExecutor->doExecute() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/Executor.php:155
[27-Dec-2020 12:27:44 UTC] PHP  18. GraphQL\Executor\ReferenceExecutor->executeOperation() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php:209
[27-Dec-2020 12:27:44 UTC] PHP  19. GraphQL\Executor\ReferenceExecutor->executeFields() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php:258
[27-Dec-2020 12:27:44 UTC] PHP  20. GraphQL\Executor\ReferenceExecutor->resolveField() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php:1200
[27-Dec-2020 12:27:44 UTC] PHP  21. GraphQL\Executor\ReferenceExecutor->resolveFieldValueOrError() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php:557
[27-Dec-2020 12:27:44 UTC] PHP  22. WPGraphQL\Utils\InstrumentSchema::WPGraphQL\Utils\{closure:/var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:119-215}() /var/www/thegsc/wp-content/plugins/wp-graphql/vendor/webonyx/graphql-php/src/Executor/ReferenceExecutor.php:630
[27-Dec-2020 12:27:44 UTC] PHP  23. call_user_func:{/var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:180}() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:180
[27-Dec-2020 12:27:44 UTC] PHP  24. WPGraphQL\Utils\InstrumentSchema::WPGraphQL\Utils\{closure:/var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:119-215}() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:180
[27-Dec-2020 12:27:44 UTC] PHP  25. call_user_func:{/var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:180}() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:180
[27-Dec-2020 12:27:44 UTC] PHP  26. WPGraphQL\Registry\TypeRegistry->WPGraphQL\Registry\{closure:/var/www/thegsc/wp-content/plugins/wp-graphql/src/Registry/TypeRegistry.php:1161-1166}() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Utils/InstrumentSchema.php:180
[27-Dec-2020 12:27:44 UTC] PHP  27. call_user_func:{/var/www/thegsc/wp-content/plugins/wp-graphql/src/Registry/TypeRegistry.php:1165}() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Registry/TypeRegistry.php:1165
[27-Dec-2020 12:27:44 UTC] PHP  28. WPGraphQL\Connection\PostObjects::WPGraphQL\Connection\{closure:/var/www/thegsc/wp-content/plugins/wp-graphql/src/Connection/PostObjects.php:360-362}() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Registry/TypeRegistry.php:1165
[27-Dec-2020 12:27:44 UTC] PHP  29. WPGraphQL\Data\DataSource::resolve_post_objects_connection() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Connection/PostObjects.php:361
[27-Dec-2020 12:27:44 UTC] PHP  30. WPGraphQL\Data\Connection\PostObjectConnectionResolver->__construct() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Data/DataSource.php:170
[27-Dec-2020 12:27:44 UTC] PHP  31. WPGraphQL\Data\Connection\PostObjectConnectionResolver->__construct() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Data/Connection/PostObjectConnectionResolver.php:67
[27-Dec-2020 12:27:44 UTC] PHP  32. WPGraphQL\Data\Connection\PostObjectConnectionResolver->get_query_args() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Data/Connection/AbstractConnectionResolver.php:185
[27-Dec-2020 12:27:44 UTC] PHP  33. apply_filters() /var/www/thegsc/wp-content/plugins/wp-graphql/src/Data/Connection/PostObjectConnectionResolver.php:355
[27-Dec-2020 12:27:44 UTC] PHP  34. WP_Hook->apply_filters() /var/www/thegsc/wp-includes/plugin.php:212
[27-Dec-2020 12:27:44 UTC] PHP  35. WPGraphQL\QL_Events\Data\Connection\Ticket_Connection_Resolver::get_ticket_args() /var/www/thegsc/wp-includes/class-wp-hook.php:287
```
