### PR TITLE
Register Pro Custom Fields

### DIFF
--- a/includes/types/object/class-event-type.php
+++ b/includes/types/object/class-event-type.php
@@ -271,5 +271,30 @@ class Event_Type {
 				),
 			)
 		);
+
+		
+		/**
+		 * Register custom meta fields.
+		 */ 
+		$custom_fields = tribe_get_option( 'custom-fields');
+
+		if ( is_array( $custom_fields ) ) {
+			foreach ( $custom_fields as $field) {
+				// Use label as graphQL key, instead of _ecp_custom_{#}.
+				$key = lcfirst( str_replace( ' ', '', ucwords( $field['label'] ) ) );
+
+				register_graphql_field(
+					'Event', 
+					$key,
+					array(
+						'type'        => 'String',
+						'description' => $field['label'],
+						'resolve'     => function ( $source, $field ) {
+							get_post_meta( $source->ID, $field['name'], true);
+						}
+					)
+				);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Registers [Pro Custom Fields ](https://theeventscalendar.com/knowledgebase/k/pro-additional-fields/) to the GraphQL `Event`. 

For ease of use, the fields are registered using their label, as the field name defined in the database is semantically meaningless ( `_ecp_custom_{#}` ).