### PR TITLE
Adds an extra item to posts_per_page to ensure that the total number …

### DIFF
--- a/includes/data/connection/class-event-connection-resolver.php
+++ b/includes/data/connection/class-event-connection-resolver.php
@@ -106,7 +106,7 @@ class Event_Connection_Resolver extends PostObjectConnectionResolver {
 		/**
 		 * Set posts_per_page the highest value of $first and $last, with a (filterable) max of 100
 		 */
-		$query_args['posts_per_page'] = $this->one_to_one ? 1 : min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 1;
+		$query_args['posts_per_page'] = $this->one_to_one ? 1 : min( max( absint( $first ), absint( $last ), 10 ), $this->query_amount ) + 2;
 
 		// set the graphql cursor args.
 		$query_args['graphql_cursor_compare'] = ( ! empty( $last ) ) ? '>' : '<';
@@ -135,6 +135,7 @@ class Event_Connection_Resolver extends PostObjectConnectionResolver {
 					'key'   => Occurrences::table_name() . '.start_date_utc',
 					'value' => $cursor_node->start_date_utc,
 					'type'  => 'DATETIME',
+					'order' => 'ASC'
 				],
 			];
 


### PR DESCRIPTION
…of items in the query remain greater than the number asked for even when one is removed as a duplicate. Adds explicit order=ASC to graphql_cursor_compare_fields. Together these changes fix a bug where hasNextPage was wrongly returning false in wpgraphql when there should be a next page of results.